### PR TITLE
Newer steamcmd requires force_install_dir before login command

### DIFF
--- a/admin-interface/docroot/views/steamcmd-tool.erb
+++ b/admin-interface/docroot/views/steamcmd-tool.erb
@@ -8,8 +8,8 @@
       <div class="p-2 col-2">Command</div>
       <div class="p-2 horizontal-expand">
 <textarea id="steamcmd_input" class="form-control monospace-font" id="exampleTextarea" rows="8">
-+login anonymous
 +force_install_dir "<%= @server_root_dir %>"
++login anonymous
 +app_update 581330 validate
 +exit
 </textarea>

--- a/admin-interface/lib/server-updater.rb
+++ b/admin-interface/lib/server-updater.rb
@@ -138,8 +138,8 @@ class ServerUpdater
   def update_server(buffer=nil, validate: nil, ignore_status: true, ignore_message: true)
     log 'Updating server', level: :info
     command = [
-      '+login anonymous',
       "+force_install_dir \"#{@server_root_dir}\"",
+      '+login anonymous',
       "+app_update 581330#{' validate' if validate}",
       '+exit'
     ]

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Install the server if not already installed
+# Install the server if not already installed 
 if [[ ! -d sandstorm-server/Insurgency ]]
 then
-  steamcmd/installation/steamcmd.sh +login anonymous +force_install_dir /home/sandstorm/sandstorm-server +app_update 581330 +quit
+  steamcmd/installation/steamcmd.sh +force_install_dir +login anonymous /home/sandstorm/sandstorm-server +app_update 581330 +quit
 fi
 
 # Start normally


### PR DESCRIPTION
I got a steam-error when calling login first and force_install_dir after.
Just changed the command-order and the error went away.