### PR TITLE
Update Dockerfile to fix currently non-working docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim-buster
+FROM ruby:3-slim-bookworm
 
 
 RUN apt-get update
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y wget make gcc
 
 # Install Steamcmd dependencies
-RUN apt-get install -y lib32gcc1
+RUN apt-get install -y lib32gcc-s1
 
 # Sandstorm server won't run under root
 RUN useradd -ms /bin/bash sandstorm
@@ -26,7 +26,7 @@ RUN rm steamcmd/installation/steamcmd_linux.tar.gz
 
 RUN cp config/config.toml.docker config/config.toml
 
-RUN gem install bundler:1.17.2
+RUN gem install bundler
 
 WORKDIR /home/sandstorm/admin-interface
 


### PR DESCRIPTION
The old dockerfile was quite outdated which probably caused my servers not to start anymore - even after reconfiguring the whole docker image. Even the projects README stated it needs at least ruby 3.1.2+ while the dockerfile was based on ruby 2.7. Also Debian Busters support ended 2022-06-30, so I also changed it to the current debian version.

I haven't tested playing on my servers after those fixes, but I can at least state that they're running again. Before it just looped with spawning-game-process messages