### PR TITLE
Docker: Add Locales Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,16 @@ RUN apt-get install -y wget make gcc
 # Install Steamcmd dependencies
 RUN apt-get install -y lib32gcc-s1
 
-# Install Locales package for Steamcmd
-RUN apt-get install -y locales
+# Install Locales package for Steamcmd to avoid Warnings about being not being able to set to en_US.UTF-8
+RUN apt-get install -y locales && \
+    # Override all localisation settings to en_US.UTF-8 as default
+    echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
+    # Tell locale.gen to generate en_US.UTF-8 with UTF-8 encoding
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    # Set the default language to en_US.UTF-8
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
+    # Run locale-gen to ensure en_US.UTF-8 is generated
+    locale-gen en_US.UTF-8
 
 # Sandstorm server won't run under root
 RUN useradd -ms /bin/bash sandstorm

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get install -y wget make gcc
 # Install Steamcmd dependencies
 RUN apt-get install -y lib32gcc-s1
 
+# Install Locales package for Steamcmd
+RUN apt-get install -y locales
+
 # Sandstorm server won't run under root
 RUN useradd -ms /bin/bash sandstorm
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 volumes:
   sandstorm_wrapper_config:
   sandstorm_server:


### PR DESCRIPTION
~~Add locales package to Docker image to avoid Steam warning: `setlocale('en_US.UTF-8') failed, using locale: 'C'.`~~

### Changes:
  - Set default localization options to `en_US.UTF-8`
  - Set default language to `en_US.UTF-8`
  - Force generate locale `en_US.UTF-8`
  - Remove deprecated `version` key from `docker-compose.yml`

Should hopefully fix:
> sandstorm-wrapper-1  | 2024-10-09 19:55:01 +0000 | INFO    | [PID 1764823 Ports 7777,27131,27015] | Server is ready (RCON and Query connected)
sandstorm-wrapper-1  | 2024-10-09 20:18:19 +0000 | ERROR   | Rescued error while getting latest build ID. See log file for SteamCMD output | Exception occurred (JSON::ParserError): unexpected token at '{WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.,
sandstorm-wrapper-1  | Redirecting stderr to '/home/sandstorm/steamcmd/Steam/logs/stderr.txt',
sandstorm-wrapper-1  | Logging directory: '/home/sandstorm/steamcmd/Steam/logs',
sandstorm-wrapper-1  | [  0%] Checking for available updates...,
sandstorm-wrapper-1  | [----] Verifying installation...,
sandstorm-wrapper-1  | UpdateUI: skip show logoSteam Console Client (c) Valve Corporation - version 1726605427,
sandstorm-wrapper-1  | -- type 'quit' to exit --,
sandstorm-wrapper-1  | Loading Steam API...IPC function call IClientUtils::GetSteamRealm took too long: 60 msec,
sandstorm-wrapper-1  | OK,
sandstorm-wrapper-1  | ,
sandstorm-wrapper-1  | Connecting anonymously to Steam Public...OK,
sandstorm-wrapper-1  | Waiting for client config...OK,
sandstorm-wrapper-1  | Waiting for user info...OK}'
sandstorm-wrapper-1  |   /usr/local/lib/ruby/3.3.0/json/common.rb:219:in `parse'
sandstorm-wrapper-1  |   /usr/local/lib/ruby/3.3.0/json/common.rb:219:in `parse'
sandstorm-wrapper-1  |   ~/admin-interface/lib/server-updater.rb:57:in `get_latest_build_id'
sandstorm-wrapper-1  |   ~/admin-interface/lib/server-updater.rb:88:in `update_available?'
sandstorm-wrapper-1  |   ~/admin-interface/lib/server-updater.rb:154:in `monitor_update'
sandstorm-wrapper-1  |   ~/admin-interface/lib/webapp.rb:231:in `block in get_game_update_thread'
sandstorm-wrapper-1  |   ~/admin-interface/ext/thread.rb:13:in `block in initialize'
sandstorm-wrapper-1  | 2024-10-09 21:13:45 +0000 | ERROR   | Rescued error while getting latest build ID. See log file for SteamCMD output | Exception occurred (JSON::ParserError): unexpected token at '{WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.,

After latest changes:
> sandstorm-wrapper-1  | Redirecting stderr to '/home/sandstorm/Steam/logs/stderr.txt'
sandstorm-wrapper-1  | Logging directory: '/home/sandstorm/Steam/logs'
sandstorm-wrapper-1  | [  0%] Checking for available updates...
sandstorm-wrapper-1  | [----] Verifying installation...
sandstorm-wrapper-1  | [  0%] Downloading update...
sandstorm-wrapper-1  | [  0%] Checking for available updates...
sandstorm-wrapper-1  | [----] Download complete.
sandstorm-wrapper-1  | [----] Extracting package...
sandstorm-wrapper-1  | [----] Extracting package...
sandstorm-wrapper-1  | [----] Extracting package...
sandstorm-wrapper-1  | [----] Extracting package...
sandstorm-wrapper-1  | [----] Installing update...