### PR TITLE
Pin Docker Base Image Tag to Specific Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3-slim-bookworm
+FROM ruby:3.3.6-slim-bookworm
 
 
 RUN apt-get update


### PR DESCRIPTION
Pin base image to specific tag to prevent upstream changes from causing issues (IE: OpenSSL issues)

Should fix problems noted here (Including missing base64 gem, which seems to have been removed on the latest tag):
https://github.com/Joe-Klauza/sandstorm-admin-wrapper/pull/148